### PR TITLE
 README.md -> Fix description and change to lowercase build123d

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Awesome build123d
 
 
-A curated list of CadQuery code and resources. Inspired by other lists like [awesome-cadquery](https://github.com/CadQuery/awesome-cadquery).
+A curated list of build123d code and resources. Inspired by other lists like [awesome-cadquery](https://github.com/CadQuery/awesome-cadquery).
 
 
 If you want to contribute, please read [this](CONTRIBUTING.md).
@@ -10,10 +10,10 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 ## Editors and IDEs
 
 
-* [BlendQuery](https://github.com/uki-dev/blendquery) - Build123d integration for Blender.
-* [Jupyter-CadQuery](https://github.com/bernhard-42/jupyter-cadquery) - View Build123d objects in JupyterLab or in a standalone viewer for any IDE.
+* [BlendQuery](https://github.com/uki-dev/blendquery) - build123d integration for Blender.
+* [Jupyter-CadQuery](https://github.com/bernhard-42/jupyter-cadquery) - View build123d objects in JupyterLab or in a standalone viewer for any IDE.
 * [OCP VSCode CAD Viewer](https://github.com/bernhard-42/vscode-ocp-cad-viewer) - A viewer for OCP based Code-CAD (CadQuery, build123d) integrated into VS Code
-* [Yet Another CAD Viewer](https://github.com/yeicor-3d/yet-another-cad-viewer) - A CAD viewer capable of displaying [OCP](https://github.com/CadQuery/OCP) models ([CadQuery](https://github.com/CadQuery/cadquery)/[Build123d](https://github.com/gumyr/build123d)/...) in a web browser.
+* [Yet Another CAD Viewer](https://github.com/yeicor-3d/yet-another-cad-viewer) - A CAD viewer capable of displaying [OCP](https://github.com/CadQuery/OCP) models ([CadQuery](https://github.com/CadQuery/cadquery)/[build123d](https://github.com/gumyr/build123d)/...) in a web browser.
 
 
 ## Extensions and Plugins
@@ -22,9 +22,9 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [bd_animation](https://github.com/bernhard-42/bd_animation) - Animation class and tutorials for build123d 
 * [bd_warehouse](https://github.com/gumyr/bd_warehouse) - bd_warehouse augments build123d with parametric parts - generated on demand - and extensions to the core build123d capabilities.
 * [dl4to4ocp](https://github.com/yeicor-3d/dl4to4ocp) - Library that helps perform [topology optimization](https://en.wikipedia.org/wiki/Topology_optimization) on
-your [OCP](https://github.com/CadQuery/OCP)-based CAD models ([CadQuery](https://github.com/CadQuery/cadquery)/[Build123d](https://github.com/gumyr/build123d)/...) using the [dl4to](https://github.com/dl4to/dl4to) library.
+your [OCP](https://github.com/CadQuery/OCP)-based CAD models ([CadQuery](https://github.com/CadQuery/cadquery)/[build123d](https://github.com/gumyr/build123d)/...) using the [dl4to](https://github.com/dl4to/dl4to) library.
  ![Tests](https://github.com/yeicor-3d/dl4to4ocp/actions/workflows/test.yml/badge.svg?branch=master)
-* [ocp-freecad-cam](https://github.com/voneiden/ocp-freecad-cam) CAM for CadQuery and Build123d by leveraging FreeCAD library. Visualizes in CQ-Editor and ocp-cad-viewer. Spiritual successor of [cq-cam](https://github.com/voneiden/cq-cam)
+* [ocp-freecad-cam](https://github.com/voneiden/ocp-freecad-cam) CAM for CadQuery and build123d by leveraging FreeCAD library. Visualizes in CQ-Editor and ocp-cad-viewer. Spiritual successor of [cq-cam](https://github.com/voneiden/cq-cam)
 
 
 ## Part Libraries and Part Generators
@@ -37,7 +37,7 @@ your [OCP](https://github.com/CadQuery/OCP)-based CAD models ([CadQuery](https:/
 ## Miscellaneous
 
 
-* [ocp-action](https://github.com/Yeicor/ocp-action/) - GitHub Action that builds OCP models (CadQuery/Build123d/...), renders them and sets up a model viewer on Github Pages. ![Tests](https://github.com/Yeicor/ocp-action/actions/workflows/ci.yml/badge.svg?branch=main)
+* [ocp-action](https://github.com/Yeicor/ocp-action/) - GitHub Action that builds OCP models (CadQuery/build123d/...), renders them and sets up a model viewer on Github Pages. ![Tests](https://github.com/Yeicor/ocp-action/actions/workflows/ci.yml/badge.svg?branch=main)
 
 
 ## Examples and Projects using build123d


### PR DESCRIPTION
Main description of this repo still references as being for CadQuery instead of build123d, also changed all occurrences of Build123d to build123d

Thanks for creating / maintaining this repo!