### PR TITLE
README.md -> add filewatcher123d, unmaintained blendquery, some cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 ## Editors and IDEs
 
 
-* [BlendQuery](https://github.com/uki-dev/blendquery) - build123d integration for Blender.
 * [Jupyter-CadQuery](https://github.com/bernhard-42/jupyter-cadquery) - View build123d objects in JupyterLab or in a standalone viewer for any IDE.
 * [OCP VSCode CAD Viewer](https://github.com/bernhard-42/vscode-ocp-cad-viewer) - A viewer for OCP based Code-CAD (CadQuery, build123d) integrated into VS Code
 * [Yet Another CAD Viewer](https://github.com/yeicor-3d/yet-another-cad-viewer) - A web-based CAD viewer for OCP models (CadQuery/build123d) that supports static site deployment. It also has a build123d playground for editing and sharing models directly in the browser ([demo](https://yeicor-3d.github.io/yet-another-cad-viewer/#pg_code_url=https://raw.githubusercontent.com/gumyr/build123d/refs/heads/dev/examples/toy_truck.py)) ![Tests](https://github.com/yeicor-3d/yet-another-cad-viewer/actions/workflows/build.yml/badge.svg?branch=master)
@@ -44,12 +43,13 @@ your [OCP](https://github.com/CadQuery/OCP)-based CAD models ([CadQuery](https:/
 
 
 * [OCP.wasm](https://github.com/Yeicor/OCP.wasm) This project ports the low-level dependencies required for build123d to run in a browser. For a fully featured frontend, check out `Yet Another CAD Viewer` (see above). ![Tests](https://github.com/Yeicor/OCP.wasm/actions/workflows/main.yml/badge.svg?branch=master)
+* [jdegenstein/filewatcher123d](https://github.com/jdegenstein/filewatcher123d) - A file watcher oriented towards use with build123d and ocp_vscode (standalone mode, no VSCode required)
 
 
 ## Examples and Projects using build123d
 
 
-* [custom-keycap-generator](https://github.com/nicola-sorace/custom-keycap-generator) - Generate custom print-ready keycap geometries using Python and build123d
+* [nicola-sorace/custom-keycap-generator](https://github.com/nicola-sorace/custom-keycap-generator) - Generate custom print-ready keycap geometries using Python and build123d
 * [BlueDrink9/keeb_snakeskin](https://github.com/BlueDrink9/keeb_snakeskin) - Create a cool PCB case and travel case for split keyboards or other custom PCBs
 * [ginkgo/trackball](https://github.com/ginkgo/trackball) - 3d-printable twist-to-scroll trackball using a Raspberry Pi Pico and two PMW3360 sensors designed using build123d
 * [jgraichen/someline](https://github.com/jgraichen/someline) - 3D printable insets for some Someline® storage boxes designed using build123d
@@ -61,3 +61,9 @@ your [OCP](https://github.com/CadQuery/OCP)-based CAD models ([CadQuery](https:/
 
 * [Official Documentation](https://build123d.readthedocs.io/en/latest/)
 * [Alternate setup](https://gist.github.com/mtancoigne/9e2b7cdfb13f2c5a2a405cfb059e9b87) with `ocp_vscode`, without VSCode
+
+
+## Legacy
+
+
+* [BlendQuery](https://github.com/uki-dev/blendquery) - build123d integration for Blender. **(⚠️Unmaintained)**


### PR DESCRIPTION
- adds jdegenstein/filewatcher123d
- moved BlendQuery to a new legacy category and marked as unmaintained (last commit was almost 1.5 years ago)
- renamed custom-keycap-generator -> nicola-sorace/custom-keycap-generator